### PR TITLE
Flip circle detection

### DIFF
--- a/src/Path.Drag.js
+++ b/src/Path.Drag.js
@@ -173,14 +173,14 @@ L.Handler.PathDrag = L.Handler.extend( /** @lends  L.Path.Drag.prototype */ {
     // console.time('transform');
 
     // we transformed in pixel space, let's stay there
-    if (polygon._originalPoints) {
+    if (polygon._point) {
+      polygon._latlng = map.layerPointToLatLng(transform(polygon._point));
+    } else if (polygon._originalPoints) {
       for (i = 0, len = polygon._originalPoints.length; i < len; i++) {
         polygon._latlngs[i] = map.layerPointToLatLng(
           transform(polygon._originalPoints[i])
         );
       }
-    } else if (polygon._point) {
-      polygon._latlng = map.layerPointToLatLng(transform(polygon._point));
     }
 
     // holes operations


### PR DESCRIPTION
Circle / CircleMarker detection doesn't work because the first test polygon._originalPoints succeeds. Instead, the presence of the _point variable should be tested first.
Also, it might be good to replace the test with something like "instanceof L.Circle" or add a comment because it is not obvious what is being tested there