### PR TITLE
Code cleanup

### DIFF
--- a/src/Path.Drag.js
+++ b/src/Path.Drag.js
@@ -142,7 +142,7 @@ L.Handler.PathDrag = L.Handler.extend( /** @lends  L.Path.Drag.prototype */ {
    * @param  {Array.<Number>} matrix
    * @return {L.Point}
    */
-  _transformPoints: function(matrix) {
+  _transformPoints: function() {
     var matrix = this._matrix;
     var a = matrix[0];
     var c = matrix[1];
@@ -153,7 +153,6 @@ L.Handler.PathDrag = L.Handler.extend( /** @lends  L.Path.Drag.prototype */ {
 
     var polygon = this._path;
     var map = this._path._map;
-    var latlngs = [];
 
     var i, j, len, len2;
 


### PR DESCRIPTION
Must have been historical variables. The matrix parameter is never used, which is confusing. The latlng array is never used either, probably not needed anymore.

Other things I see:
- I would also either change the variable name "polygon" which is misleading (it is any path, really) and not really useful. Either rename it to path or use this._path directly.
- I believe the transform function should also be out of the _transformPoints function, makes it more readable. Should be a "static" function and not an object's function
- Use the L.Point.clone function instead of L.point(evt.containerPoint) or L.point(evt.containerPoint.x, evt.containerPoint.y);