### PR TITLE
Return transformed coordinates when dragging in progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# IDE
+*.iml

--- a/src/Path.Drag.js
+++ b/src/Path.Drag.js
@@ -261,7 +261,7 @@ L.Circle.prototype.getLatLng = function() {
   }
 };
 
-L.Polyline.prototype._getLatLngs = L.Polyline.prototype.getLatLngs();
+L.Polyline.prototype._getLatLngs = L.Polyline.prototype.getLatLngs;
 L.Polyline.prototype.getLatLngs = function() {
   if (this.dragging && this.dragging.inProgress()) {
     var points = this._getLatLngs();


### PR DESCRIPTION
Hi @w8r,

Thank you for your work and for your plugin.

This small PR contains little refactoring to extract method to allow transformation of single points according to the provided transformation matrix. I need this change to implement PR in your another plugin: https://github.com/w8r/Leaflet.draw.drag

UPDATE: I realized, that all my changes should be part of this plugin, not Leaflet.draw.drag. So I moved changes from https://github.com/w8r/Leaflet.draw.drag/pull/9 here.

Description from https://github.com/w8r/Leaflet.draw.drag/pull/9 still applies here. In short: now, when dragging in progress, when we call `getLatLng` method of `L.Circle` or `getLatLngs` of L.Polyline - we will get transformed points (according to transformation matrix). It allows us to get actual positions when dragging in progress.

Thanks,
Kirill